### PR TITLE
Add support for Mastodon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,12 @@ jobs:
       - name: Test run
         run: |
           python randimgbot.py --help
-          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 100000
-          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 1
+
+          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 100000 --mastodon
+          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 1      --mastodon
+
+          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 100000 --twitter
+          python randimgbot.py --test --yaml data/randimgbot_example.yaml --inspec data/randimgbot_example.json --chance 1      --twitter
 
   success:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["pypy3.9", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
 # randimgbot
 
 [![Test](https://github.com/hugovk/randimgbot/actions/workflows/test.yml/badge.svg)](https://github.com/hugovk/randimgbot/actions/workflows/test.yml)
-[![Python: 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/)
+[![Python: 3.7+](https://img.shields.io/badge/Python-3.7+-blue.svg)](https://www.python.org/downloads/)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
-Pick a random image and tweet it.
+Pick a random image and toot or tweet it.
 
 ## Example
 
-Randimgbot powers **[@FlagFacts](https://twitter.com/FlagFacts)**.
+Randimgbot powers
+**[@FlagFacts@botsin.space on Mastodon](https://botsin.space/@FlagFacts)** and
+**[@FlagFacts on Twitter](https://twitter.com/FlagFacts)**.
 
-## Set up
+## Set up Mastodon
+
+Create an account at:
+
+https://botsin.space/auth/sign_up
+
+Follow https://gist.github.com/aparrish/661fca5ce7b4882a8c6823db12d42d26 to create a
+client ID, client secret, and access token, and store in YAML file. See
+`data/randimgbot_example.yaml`.
+
+## Set up Twitter
 
 Create and authorise an app with (read and) write access at:
 
@@ -18,7 +30,7 @@ https://dev.twitter.com/apps/new
 
 Store credentials in YAML file. See `data/randimgbot_example.yaml`.
 
-Install dependencies:
+## Install dependencies
 
 ```bash
 pip install -r requirements.txt
@@ -31,6 +43,9 @@ Call something like:
 ```bash
 python randimgbot.py -y path/to/randimgbot.yaml -i path/to/dir/full/of/images/*.jpg -t "Random thing: {0} #randomthing {1}"
 ```
+
+- Add `--mastodon` to post to Mastodon.
+- Add `--twitter` to post to Twitter.
 
 Where `{0}` will be replaced with a name taken from the filename, and `{1}` is a hashtag
 from the name. Either or both can be omitted.

--- a/data/randimgbot_example.yaml
+++ b/data/randimgbot_example.yaml
@@ -2,3 +2,7 @@ consumer_key: TODO_ENTER_YOURS_HERE
 consumer_secret: TODO_ENTER_YOURS_HERE
 oauth_token: TODO_ENTER_YOURS_HERE
 oauth_token_secret: TODO_ENTER_YOURS_HERE
+
+mastodon_client_id: TODO_ENTER_YOURS_HERE
+mastodon_client_secret: TODO_ENTER_YOURS_HERE
+mastodon_access_token: TODO_ENTER_YOURS_HERE

--- a/randimgbot.py
+++ b/randimgbot.py
@@ -14,6 +14,7 @@ import webbrowser
 from pprint import pprint
 
 import yaml  # pip install pyyaml
+from mastodon import Mastodon  # pip install Mastodon.py
 from twitter import OAuth, Twitter  # pip install twitter
 
 
@@ -22,12 +23,19 @@ def timestamp():
     print(datetime.datetime.now().strftime("%A, %d. %B %Y %I:%M%p") + " " + __file__)
 
 
-def load_yaml(filename):
-    """Load Twitter credentials from a YAML file"""
+def load_yaml(filename, mastodon, twitter):
+    """Load credentials from a YAML file"""
     with open(filename) as f:
         data = yaml.safe_load(f)
 
-    if not data.keys() >= {
+    if mastodon and not data.keys() >= {
+        "mastodon_client_id",
+        "mastodon_client_secret",
+        "mastodon_access_token",
+    }:
+        sys.exit(f"Mastodon credentials missing from YAML: {filename}")
+
+    if twitter and not data.keys() >= {
         "oauth_token",
         "oauth_token_secret",
         "consumer_key",
@@ -37,7 +45,7 @@ def load_yaml(filename):
     return data
 
 
-def random_img_and_text(spec):
+def random_img_and_text(spec: str) -> tuple[str, str]:
     """Find images (non-recursively) in dirname"""
     import glob
 
@@ -72,7 +80,7 @@ def random_img_and_text(spec):
     return random_image, text
 
 
-def text_from_filename(filename):
+def text_from_filename(filename: str) -> str:
     r"""Return 'abc def' from C:\dir\abc_def.jpg"""
 
     # Get filename without path
@@ -88,22 +96,68 @@ def text_from_filename(filename):
     return name
 
 
-def hashtagify(text):
+def hashtagify(text: str) -> str:
     """Remove spaces and prepend a hash"""
     return "#" + text.replace(" ", "")
 
 
-def open_url(url):
-    """Open URL in a web browser"""
-    print(url)
-    if not args.no_web:
+def toot_it(
+    status: str,
+    image_path: str,
+    credentials: dict[str, str],
+    *,
+    test: bool = False,
+    no_web: bool = False,
+) -> None:
+    """Toot string with an image"""
+    if len(status) <= 0:
+        return
+
+    # Create and authorise an app with (read and) write access following:
+    # https://gist.github.com/aparrish/661fca5ce7b4882a8c6823db12d42d26
+    # Store credentials in YAML file
+    api = Mastodon(
+        credentials["mastodon_client_id"],
+        credentials["mastodon_client_secret"],
+        credentials["mastodon_access_token"],
+        api_base_url="https://botsin.space",
+    )
+
+    print("TOOTING THIS:\n", status)
+
+    if test:
+        print("(Test mode, not actually tooting)")
+        return
+
+    media_ids = []
+    if image_path:
+        print("Upload image")
+
+        media = api.media_post(media_file=image_path)
+        media_ids.append(media["id"])
+
+    # No geolocation on Mastodon
+    # https://github.com/mastodon/mastodon/issues/8340
+    # lat, long = closest_point_to_pluto.closest_point_to_pluto()
+
+    toot = api.status_post(status, media_ids=media_ids, visibility="public")
+
+    url = toot["url"]
+    print("Tooted:\n" + url)
+    if not no_web:
         webbrowser.open(url, new=2)  # 2 = open in a new tab, if possible
 
 
-def tweet_it(string, img, credentials):
+def tweet_it(
+    status: str,
+    image_path: str,
+    credentials: dict[str, str],
+    *,
+    test: bool = False,
+    no_web: bool = False,
+):
     """Tweet string with an image"""
-    if len(string) <= 0:
-        # TODO error
+    if len(status) <= 0:
         return
 
     # Create and authorise an app with (read and) write access at:
@@ -118,33 +172,38 @@ def tweet_it(string, img, credentials):
         )
     )
 
-    print("TWEETING THIS:\n" + string)
+    print("TWEETING THIS:\n" + status)
 
-    if args.test:
+    if test:
         print("(Test mode, not actually tweeting)")
-    else:
-        with open(img, "rb") as imagefile:
-            params = {"media[]": imagefile.read(), "status": string}
-            result = t.statuses.update_with_media(**params)
-            url = (
-                "https://twitter.com/"
-                + result["user"]["screen_name"]
-                + "/status/"
-                + result["id_str"]
-            )
-            print("Tweeted:\n" + url)
-            if not args.no_web:
-                # 2 = open in a new tab, if possible
-                webbrowser.open(url, new=2)
+        return
+
+    with open(image_path, "rb") as image_file:
+        params = {"media[]": image_file.read(), "status": status}
+        result = t.statuses.update_with_media(**params)
+        url = (
+            "https://twitter.com/"
+            + result["user"]["screen_name"]
+            + "/status/"
+            + result["id_str"]
+        )
+        print("Tweeted:\n" + url)
+        if not no_web:
+            # 2 = open in a new tab, if possible
+            webbrowser.open(url, new=2)
 
 
 if __name__ == "__main__":
     timestamp()
 
+
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Pick a random image and tweet it",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
+    parser.add_argument("--mastodon", action="store_true", help="Post to Mastodon")
+    parser.add_argument("--twitter", action="store_true", help="Post to Twitter")
     parser.add_argument(
         "-y",
         "--yaml",
@@ -170,32 +229,36 @@ if __name__ == "__main__":
         "--chance",
         type=int,
         default=12,
-        help="Denominator for the chance of tweeting this time",
+        help="Denominator for the chance of tweeting/tooting this time",
     )
     parser.add_argument(
-        "-x", "--test", action="store_true", help="Test mode: don't tweet"
+        "-x", "--test", action="store_true", help="Test mode: don't tweet/toot"
     )
     parser.add_argument(
         "-nw",
         "--no-web",
         action="store_true",
-        help="Don't open a web browser to show the tweeted tweet",
+        help="Don't open a web browser to show the tweeted tweet/tooted toot",
     )
     args = parser.parse_args()
 
-    # Do we have a chance of tweeting this time?
+    # Do we have a chance of posting this time?
     if random.randrange(args.chance) > 0:
-        print("No tweet this time")
+        print("No post this time")
         sys.exit()
 
-    twitter_credentials = load_yaml(args.yaml)
+    credentials = load_yaml(args.yaml, args.mastodon, args.twitter)
 
-    img, text = random_img_and_text(args.inspec)
+    image_path, text = random_img_and_text(args.inspec)
     hashtag = hashtagify(text)
 
-    tweet = args.template.format(text, hashtag)
-    print("Tweet this:\n" + tweet)
+    status = args.template.format(text, hashtag)
+    print("Post this:\n" + status)
+    if args.mastodon:
+        toot_it(status, image_path, credentials, test=args.test, no_web=args.no_web)
+    if args.twitter:
+        tweet_it(status, image_path, credentials, test=args.test, no_web=args.no_web)
 
-    tweet_it(tweet, img, twitter_credentials)
 
-# End of file
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Mastodon.py
 PyYAML
 twitter

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
 
-python3 randimgbot.py --yaml ~/bin/data/flagfacts.yaml --no-web  -i "~/github/flagfactsflags/flags/*.png" -t "{0}" --chance 6
+python3 randimgbot.py --yaml ~/bin/data/flagfacts.yaml --no-web  -i "~/github/flagfactsflags/flags/*.png" -t "{0}" --chance 6 --mastodon
+python3 randimgbot.py --yaml ~/bin/data/flagfacts.yaml --no-web  -i "~/github/flagfactsflags/flags/*.png" -t "{0}" --chance 6 --twitter


### PR DESCRIPTION
Goodbye Twitter https://twitter.com/TwitterDev/status/1621026986784337922

Created the Mastodon credentials using this helper script:

```python
"""
Get credentials for the Mastodon API with Mastodon.py

Based on this gist by Allison Parrish
https://gist.github.com/aparrish/661fca5ce7b4882a8c6823db12d42d26
"""
import argparse

from mastodon import Mastodon  # pip install Mastodon.py


def mastodon_create_app(
    app_name: str, email: str, password: str, instance: str
) -> None:
    client_id, client_secret = Mastodon.create_app(
        app_name, scopes=["read", "write"], api_base_url=instance
    )

    print(f"mastodon_client_id: {client_id}")
    print(f"mastodon_client_secret: {client_secret}")

    api = Mastodon(client_id, client_secret, api_base_url=instance)
    access_token = api.log_in(email, password, scopes=["read", "write"])

    print(f"mastodon_access_token: {access_token}")


def main() -> None:
    parser = argparse.ArgumentParser(
        description="TODO",
        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
    )
    parser.add_argument("app_name", help="Your app name")
    parser.add_argument("email", help="Email you used to create your bot's account")
    parser.add_argument(
        "password", help="Password you used to create your bot's account"
    )
    parser.add_argument(
        "--instance", default="https://botsin.space", help="Mastodon instance"
    )
    args = parser.parse_args()
    mastodon_create_app(args.app_name, args.email, args.password, args.instance)


if __name__ == "__main__":
    main()
```